### PR TITLE
Query for updated projects list if missing in cache

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -308,7 +308,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                             .await;
                                     }
                                     VimCommand::ProjectOpen(name) => {
-                                        app.select_project(&String::from(name));
+                                        app.select_project(&String::from(name)).await;
                                         app.sync().await;
                                     }
                                     _ => {}


### PR DESCRIPTION
if a new project is created, it is not possible to open this project (e.g. if you open another) until restart. this occurs because the projects list is only queried at startup. the solution here is to attempt to resolve project selection from the local cache first, and query the gist if not found.