### PR TITLE
Fix out of sync new project

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -430,11 +430,11 @@ impl App {
     #[allow(unused_must_use)]
     pub async fn new_project(&mut self, project: &str) {
         self.current_project = Some(project.to_string());
-        self.tasks.drain(..);
-        self.save_project(false, true);
-
         self.client_config.current_project = self.current_project.to_owned();
         self.client_config.save_config();
+
+        self.tasks.drain(..);
+        self.save_project(false, true);
     }
 
     pub fn save_project(&mut self, wait: bool, sync: bool) {


### PR DESCRIPTION
when creating a new project, the app registers it in the gist but doesn't actually load it locally. however, it does clear the task list, which can lead to corruption. the fix is just to make sure init() is not called before the current project is set.