### PR TITLE
Display project in header, add refresh key

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -226,6 +226,9 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                     app.wont_task(&w.id.as_ref().unwrap())
                                 }
                             }
+                            Key::Char('r') => {
+                                app.sync().await;
+                            }
                             Key::Char('i') => app.mode = AppMode::Insert,
                             Key::Char(':') => {
                                 app.mode = AppMode::Command;

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -248,7 +248,11 @@ fn draw_table<B>(
         .map(|h| Constraint::Length(h.width))
         .collect::<Vec<tui::layout::Constraint>>();
 
-    let title = format!("Tasks({}):", app.filter);
+    let title = format!(
+        "{}({}):",
+        app.current_project.as_ref().unwrap_or(&"Tasks".to_string()),
+        app.filter,
+    );
 
     Table::new(header.items.iter().map(|h| h.text), rows)
         .block(


### PR DESCRIPTION
displaying the open project in the title bar is a nice quality of life feature when you have multiple projects. this also adds a bind for refreshing from the gist, which is useful for debugging.