### PR TITLE
More vimlike things (round 1)

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -37,7 +37,7 @@ pub fn parse_text_parts(parts: &mut SplitWhitespace) -> Option<String> {
 
 #[derive(PartialEq, Eq, Clone, Hash, Debug)]
 pub enum VimCommand {
-    TaskModify(usize, String),
+    TaskRename(usize, String),
     TaskDelete(usize),
     TaskSetPriority(usize, usize),
     ProjectNew(String),
@@ -64,7 +64,7 @@ impl VimCommand {
                 let index = tokens.next().unwrap();
                 let content = parse_text_parts(&mut tokens)
                     .unwrap_or(String::from("Invalid"));
-                VimCommand::TaskModify(index.parse::<usize>().unwrap(), content)
+                VimCommand::TaskRename(index.parse::<usize>().unwrap(), content)
             }
             "tdel" => {
                 let index = tokens.next().unwrap();
@@ -543,7 +543,7 @@ impl App {
         }
     }
 
-    pub fn fix_all_work_tems(&mut self) {
+    pub fn fix_all_work_items(&mut self) {
         for x in self.tasks.iter_mut() {
             x.id = Some(Uuid::new_v4().to_string());
         }

--- a/src/app.rs
+++ b/src/app.rs
@@ -371,6 +371,7 @@ pub struct App {
     pub mode: AppMode,
     pub current_project: Option<String>,
     pub current_file_list: Option<ListGist>,
+    pub register: Option<WorkItem>,
 }
 
 impl App {
@@ -386,6 +387,7 @@ impl App {
             mode: AppMode::Global,
             current_project: None,
             current_file_list: None,
+            register: None,
         }
     }
 
@@ -533,12 +535,25 @@ impl App {
         }
     }
 
+    pub fn add_task(&mut self, mut item: WorkItem) {
+        item.id = Some(Uuid::new_v4().to_string());
+        self.tasks.push(item);
+        self.tasks.sort_by(|a, b| {
+            a.status.partial_cmp(&b.status).unwrap()
+        });
+        self.selected_index = self.tasks.len() - 1;
+        self.mode = AppMode::Global;
+        self.insert_bar.clear();
+        self.save_project(false, false);
+    }
+
     pub fn remove_task(&mut self, id: &str) {
         if let Some(task) = self
             .tasks
             .iter_mut()
             .position(|s| s.id == Some(id.to_string()))
         {
+            self.register = Some(self.tasks[task].clone());
             self.tasks.remove(task);
         }
     }

--- a/src/app.rs
+++ b/src/app.rs
@@ -78,11 +78,11 @@ impl VimCommand {
                     value.parse::<usize>().unwrap(),
                 )
             }
-            "popen" => {
+            "o" => {
                 let name = tokens.next().unwrap();
                 VimCommand::ProjectOpen(String::from(name))
             }
-            "pnew" => {
+            "n" => {
                 let name = tokens.next().unwrap();
                 VimCommand::ProjectNew(String::from(name))
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -226,6 +226,18 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                     app.wont_task(&w.id.as_ref().unwrap())
                                 }
                             }
+                            Key::Char('d') => {
+                                if let Some(w) =
+                                    current_view.get_mut(app.selected_index)
+                                {
+                                    app.remove_task(&w.id.as_ref().unwrap())
+                                }
+                            }
+                            Key::Char('p') => {
+                                if app.register.is_some() {
+                                    app.add_task(app.register.as_ref().unwrap().clone());
+                                }
+                            }
                             Key::Char('i') => app.mode = AppMode::Insert,
                             Key::Char(':') => {
                                 app.mode = AppMode::Command;
@@ -251,16 +263,8 @@ async fn main() -> Result<(), Box<dyn Error>> {
                     AppMode::Insert => match app.insert_bar.handle_input(key) {
                         VimCommandBarResult::Finished(task) => {
                             let mut work_item = WorkItem::new();
-                            work_item.id = Some(Uuid::new_v4().to_string());
                             work_item.content = Some(task);
-                            app.tasks.push(work_item);
-                            app.tasks.sort_by(|a, b| {
-                                a.status.partial_cmp(&b.status).unwrap()
-                            });
-                            app.selected_index = app.tasks.len() - 1;
-                            app.mode = AppMode::Global;
-                            app.insert_bar.clear();
-                            app.save_project(false, false);
+                            app.add_task(work_item);
                         }
                         VimCommandBarResult::Aborted => {
                             app.mode = AppMode::Global

--- a/src/main.rs
+++ b/src/main.rs
@@ -186,12 +186,12 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
         match events.next()? {
             event::Event::Input(key) => {
-                if key == Key::Ctrl('c') {
+                if key == Key::Ctrl('d') {
                     close_application()?;
                     break;
                 }
 
-                if key == Key::Esc {
+                if key == Key::Ctrl('c') || key == Key::Esc {
                     app.insert_bar.clear();
                     app.command_bar.clear();
                     app.mode = AppMode::Global;
@@ -209,8 +209,8 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                     app.start_task(&w.id.as_ref().unwrap())
                                 }
                             }
-                            Key::Char('k') => {
-                                app.fix_all_work_tems();
+                            Key::Char('x') => {
+                                app.fix_all_work_items();
                             }
                             Key::Char('f') => {
                                 if let Some(w) =
@@ -231,14 +231,14 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                 app.mode = AppMode::Command;
                                 app.command_bar.handle_input(key);
                             }
-                            Key::Up => {
+                            Key::Up | Key::Char('k') => {
                                 let next_index = on_up_press_handler(
                                     &app.tasks,
                                     Some(app.selected_index),
                                 );
                                 app.selected_index = next_index;
                             }
-                            Key::Down => {
+                            Key::Down | Key::Char('j') => {
                                 let next_index = on_down_press_handler(
                                     &app.tasks,
                                     Some(app.selected_index),
@@ -284,7 +284,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                     VimCommand::ProjectSave => {
                                         app.save_project(false, false);
                                     }
-                                    VimCommand::TaskModify(index, content) => {
+                                    VimCommand::TaskRename(index, content) => {
                                         if let Some(w) =
                                             current_view.get_mut(index)
                                         {
@@ -313,6 +313,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                     }
                                     _ => {}
                                 };
+                                app.mode = AppMode::Global
                             }
                             VimCommandBarResult::Aborted => {
                                 app.mode = AppMode::Global


### PR DESCRIPTION
changes made:
- control C matches behavior of ESC, which is on par with vim. control D replaces old force quit behavior
- standard movement keys control the cursor
- app returns to global mode after successful command execution
- delete functionality with cursor added, which feels intuitive. also yanks to register. I only implemented this because I wanted to move tasks between projects more easily.
- :popen => :o and :pnew => :n